### PR TITLE
Focus search area on page load/change + improve search placeholder text

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useLocation } from 'react-router-dom';
 import FormControl from "@mui/material/FormControl";
 import Input from "@mui/material/Input";
 import InputAdornment from "@mui/material/InputAdornment";
@@ -11,13 +12,18 @@ interface ISearchInputProps {
 }
 
 export default function SearchInput({ q, qChange }: ISearchInputProps) {
+  const location = useLocation();
+  const pathname = location.pathname;
+  const searchType = pathname.replaceAll("/", "").replaceAll("-", " ");
+  const SearchLabelText = `Search ${searchType}`;
+
   return (
     <>
       <FormControl variant="standard">
         <Input
           value={q}
           onChange={(e) => qChange(e.target.value)}
-          placeholder="Search"
+          placeholder={SearchLabelText}
           startAdornment={
             <>
               {q.length > 0 ? (

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -6,6 +6,10 @@ import InputAdornment from "@mui/material/InputAdornment";
 import SearchIcon from "@mui/icons-material/Search";
 import SearchOffIcon from "@mui/icons-material/SearchOff";
 
+function searchTypeFromUrl(pathname: string): string {
+  return pathname.replaceAll("-", " ").replaceAll("/", "");
+}
+
 interface ISearchInputProps {
   q: string;
   qChange: (newQ: string) => void;
@@ -14,7 +18,8 @@ interface ISearchInputProps {
 export default function SearchInput({ q, qChange }: ISearchInputProps) {
   const location = useLocation();
   const pathname = location.pathname;
-  const searchType = pathname.replaceAll("/", "").replaceAll("-", " ");
+
+  const searchType = searchTypeFromUrl(pathname);
   const SearchLabelText = `Search ${searchType}`;
 
   return (

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -24,6 +24,7 @@ export default function SearchInput({ q, qChange }: ISearchInputProps) {
           value={q}
           onChange={(e) => qChange(e.target.value)}
           placeholder={SearchLabelText}
+          autoFocus
           startAdornment={
             <>
               {q.length > 0 ? (


### PR DESCRIPTION
This is React's autoFocus, NOT  the input autofocus attribute.
I've read React's uses `.focus` internally, so it works when the component remounts on changing pages (least I think that's what's happening)
https://blog.maisie.ink/react-ref-autofocus/#time-for-react