### PR TITLE
specify image size to avoid layout shift on image load

### DIFF
--- a/src/Nav.tsx
+++ b/src/Nav.tsx
@@ -54,7 +54,7 @@ interface NavIconLinkProps {
 function NavIconLink({ title, icon, iconWidth }: NavIconLinkProps) {
   // Check if the icon is base64 img data or assume it's an SVG Icon Component
   return typeof icon === "string" ? (
-    <img src={icon} width={iconWidth} alt={title} />
+    <img src={icon} height={iconWidth} width={iconWidth} alt={title} />
   ) : (
     React.createElement(icon, { sx: { fontSize: `${iconWidth}px` } })
   );

--- a/src/pages/Creatures.tsx
+++ b/src/pages/Creatures.tsx
@@ -157,6 +157,8 @@ export default function Creatures() {
                 >
                   <TableCell align="center" sx={{ width: "32px" }} scope="row">
                     <img
+                      width="64"
+                      height="64"
                       src={creature.battle_sprite}
                       alt={`${creature.name} Battle Sprite`}
                       aria-hidden="true"
@@ -172,6 +174,7 @@ export default function Creatures() {
                   <TableCell align="center">
                     <img
                       src={creature.klass.icon}
+                      height="32"
                       width="32"
                       alt={`${creature.name} Klass Icon ${creature.klass.name}`}
                       aria-hidden="true"
@@ -187,6 +190,7 @@ export default function Creatures() {
                   <TableCell align="center">
                     <img
                       src={creature.race.icon}
+                      height="32"
                       width="32"
                       alt={`${creature.name} Race Icon ${creature.race.name}`}
                       aria-hidden="true"

--- a/src/pages/Perks.tsx
+++ b/src/pages/Perks.tsx
@@ -152,6 +152,7 @@ export default function Perks() {
                 >
                   <TableCell>
                     <img
+                      height="32"
                       width="32"
                       src={perk.specialization.icon}
                       alt={`Perk Specialization Icon ${perk.specialization.name}`}

--- a/src/pages/Spells.tsx
+++ b/src/pages/Spells.tsx
@@ -133,6 +133,7 @@ export default function Spells() {
                     <img
                       src={spell.klass.icon}
                       width="32"
+                      height="32"
                       alt={`${spell.name} Klass Icon ${spell.klass.name}`}
                       aria-hidden="true"
                     />

--- a/src/pages/StatusEffects.tsx
+++ b/src/pages/StatusEffects.tsx
@@ -145,6 +145,7 @@ export default function StatusEffects() {
                   <TableCell>
                     <img
                       width="32"
+                      height="32"
                       src={statusEffect.icon}
                       alt={`Status Effect Icon ${statusEffect.name}`}
                       aria-hidden="true"


### PR DESCRIPTION
More noticeable on slow connections, but lighthouse recommended specifying the image width and height so the layout can be known in advance (avoids layout shift)